### PR TITLE
fix: windows build

### DIFF
--- a/qmidiplayer-desktop/qmpmainwindow.cpp
+++ b/qmidiplayer-desktop/qmpmainwindow.cpp
@@ -786,8 +786,8 @@ bool qmpMainWindow::isDarkTheme()
 void qmpMainWindow::startRender()
 {
 #ifdef _WIN32
-    char *ofstr = wcsto8bit((plistw->getSelectedItem() + QString(".wav")).toStdWString().c_str());
-    char *ifstr = wcsto8bit(plistw->getSelectedItem().toStdWString().c_str());
+    char *ofstr = wcsto8bit((plistw->getCurrentItem() + QString(".wav")).toStdWString().c_str());
+    char *ifstr = wcsto8bit(plistw->getCurrentItem().toStdWString().c_str());
     fluidrenderer = new qmpFileRendererFluid(ifstr, ofstr);
     playerSetup(fluidrenderer);
     fluidrenderer->renderInit();


### PR DESCRIPTION
The API change of `getSelectedItem()` to `getCurrentItem()` is missing from the `_WIN32` macro section. This patch fixes this issue which will cause build failed.