### PR TITLE
fix: missing link libraries path for windows build

### DIFF
--- a/qmidiplayer-desktop/CMakeLists.txt
+++ b/qmidiplayer-desktop/CMakeLists.txt
@@ -79,6 +79,16 @@ target_link_libraries(qmidiplayer
     ${CMAKE_DL_LIBS}
 )
 
+if(WIN32)
+    target_link_libraries(qmidiplayer winmm)
+endif()
+
+target_link_directories(qmidiplayer
+PRIVATE
+    ${fluidsynth_LIBRARY_DIRS} 
+    ${rtmidi_LIBRARY_DIRS}
+)
+
 file(GLOB qmpdesktop_TS_FILES translations/*.ts)
 qt5_create_translation(qmpdesktop_QM_FILES ${qmpdesktop_SOURCES} ${qmpdesktop_TS_FILES})
 add_custom_target(translations ALL DEPENDS ${qmpdesktop_QM_FILES})

--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -13,8 +13,8 @@ if(WIN32)
     list(APPEND visualization_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/visualization.rc)
 endif(WIN32)
 
-set(BUILD_DUMB ON)
-set(BUILD_EXAMPLE OFF)
+option(BUILD_DUMB "SMELT override: disable sound support" ON)
+option(BUILD_EXAMPLE "SMELT override: build example" OFF)
 add_subdirectory(SMELT)
 
 add_subdirectory(renderer)
@@ -41,7 +41,7 @@ target_link_libraries(visualization
     ${ZLIB_LIBRARIES}
     ${IL_LIBRARIES}
     glfw
-    ${GLEW_LIBRARIES}
+    GLEW::glew
     OpenGL::GL
 )
 

--- a/visualization/renderer/CMakeLists.txt
+++ b/visualization/renderer/CMakeLists.txt
@@ -23,4 +23,8 @@ target_link_libraries(qmpvisrender
     ${CMAKE_DL_LIBS}
 )
 
+if(WIN32)
+    target_link_libraries(qmpvisrender winmm)
+endif()
+
 install(TARGETS qmpvisrender)


### PR DESCRIPTION
Follow up of #10 , this patch fixes missing link directories when try building under Windows.