### PR TITLE
Add MSYS2 ci build for windows

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -31,7 +31,7 @@ jobs:
           cmake --build . --target install
           cd ../../../
           tree
-      - name: install mingw-w64-x86_64-fluidsynth
+      - name: install mingw-w64-x86_64-fluidsynth if needed
         if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
         run: |
           pacman --noconfirm -S mingw-w64-x86_64-fluidsynth
@@ -68,14 +68,31 @@ jobs:
           cp $MINGW_PREFIX/bin/libIL.dll ./
           cp $MINGW_PREFIX/bin/libfreetype-6.dll ./
           # some other dlls
+          cp $MINGW_PREFIX/bin/libstdc++-6.dll ./
+          cp $MINGW_PREFIX/bin/libintl-8.dll ./
           cp $MINGW_PREFIX/bin/libpng16-16.dll ./
           cp $MINGW_PREFIX/bin/libsndfile-1.dll ./
           cp $MINGW_PREFIX/bin/libreadline8.dll ./
           cp $MINGW_PREFIX/bin/libpcre2-16-0.dll ./
+          cp $MINGW_PREFIX/bin/libpcre-1.dll ./
           cp $MINGW_PREFIX/bin/libharfbuzz-0.dll ./
           cp $MINGW_PREFIX/bin/libdouble-conversion.dll ./
           cp $MINGW_PREFIX/bin/libicuuc67.dll ./
+          cp $MINGW_PREFIX/bin/libicudt67.dll ./
           cp $MINGW_PREFIX/bin/libicuin67.dll ./
+          cp $MINGW_PREFIX/bin/libzstd.dll ./
+          cp $MINGW_PREFIX/bin/libFLAC-8.dll ./
+          cp $MINGW_PREFIX/bin/libogg-0.dll ./
+          cp $MINGW_PREFIX/bin/libtermcap-0.dll ./
+          cp $MINGW_PREFIX/bin/libopus-0.dll ./
+          cp $MINGW_PREFIX/bin/libvorbis-0.dll ./
+          cp $MINGW_PREFIX/bin/libvorbis-0.dll ./
+          cp $MINGW_PREFIX/bin/libvorbisenc-2.dll ./
+          cp $MINGW_PREFIX/bin/libgraphite2.dll ./
+          cp $MINGW_PREFIX/bin/libiconv-2.dll ./
+          cp $MINGW_PREFIX/bin/libbz2-1.dll ./
+          cp $MINGW_PREFIX/bin/libbrotlidec.dll ./
+          cp $MINGW_PREFIX/bin/libbrotlicommon.dll ./
           # copy plugins
           mkdir plugins
           cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/
@@ -85,7 +102,7 @@ jobs:
           cp ../COPYING ./
           # done
           cd ../
-      - name: install libglib-2.0-0.dll
+      - name: install libglib-2.0-0.dll if needed
         if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
         run: |
           cd package_workspace

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -40,8 +40,19 @@ jobs:
           mkdir package_workspace && cd package_workspace
           cp ../build/qmidiplayer-desktop/qmidiplayer.exe ./
           windeployqt --no-quick-import --no-translations --no-opengl-sw --no-angle --no-system-d3d-compiler ./qmidiplayer.exe
+          # direct depts
           cp $MINGW_PREFIX/bin/libfluidsynth-2.dll ./
           cp $MINGW_PREFIX/bin/librtmidi.dll ./
+          # some other dlls
+          cp $MINGW_PREFIX/bin/libpcre2-16-0.dll ./
+          cp $MINGW_PREFIX/bin/libdouble-conversion.dll ./
+          cp $MINGW_PREFIX/bin/libicuuc67.dll ./
+          cp $MINGW_PREFIX/bin/libicuin67.dll ./
+          # copy plugins
+          mkdir plugins
+          cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/
+          cp ../build/simple-visualization/libsimple-visualization.dll ./plugins/
+          cp ../build/visualization/libvisualization.dll ./plugins/
       - uses: actions/upload-artifact@v2
         with:
           name: msys2-mingw-w64-x86_64-windows

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -59,6 +59,14 @@ jobs:
           cp $MINGW_PREFIX/bin/libfluidsynth-2.dll ./
           cp $MINGW_PREFIX/bin/librtmidi.dll ./
           cp $MINGW_PREFIX/bin/libportaudio-2.dll ./
+          # standalone visualization renderer
+          cp ../build/renderer/qmpvisrender.exe ./
+          # copy plugins
+          mkdir plugins
+          cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/
+          cp ../build/simple-visualization/libsimple-visualization.dll ./plugins/
+          cp ../build/visualization/libvisualization.dll ./plugins/
+          cp ../build/sample-plugin/libsampleplugin.dll ./plugins/
           # visualization plugin depts
           cp $MINGW_PREFIX/bin/glfw3.dll ./
           cp $MINGW_PREFIX/bin/glew32.dll ./
@@ -93,11 +101,6 @@ jobs:
           cp $MINGW_PREFIX/bin/libbz2-1.dll ./
           cp $MINGW_PREFIX/bin/libbrotlidec.dll ./
           cp $MINGW_PREFIX/bin/libbrotlicommon.dll ./
-          # copy plugins
-          mkdir plugins
-          cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/
-          cp ../build/simple-visualization/libsimple-visualization.dll ./plugins/
-          cp ../build/visualization/libvisualization.dll ./plugins/
           # license file
           cp ../COPYING ./
           # done

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install mingw-w64-x86_64-fluidsynth
         if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
         run: |
-          pacman -S mingw-w64-x86_64-fluidsynth
+          pacman --noconfirm -S mingw-w64-x86_64-fluidsynth
       - name: build rtmidi
         run: |
           # mkdir dept_workspace

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -22,9 +22,10 @@ jobs:
           mkdir dept_workspace && cd dept_workspace
           git clone --depth=1 https://github.com/thestk/rtmidi.git
           cd rtmidi && mkdir build && cd build
-          cmake .. -G Ninja
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
           cmake --build . --target install
           cd ../../../
+          tree
       - name: build qmidiplayer
         run: |
           mkdir build && cd build

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -1,0 +1,33 @@
+name: Windows MSYS2 Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git mingw-w64-x86_64-toolchain mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake tree
+            mingw-w64-x86_64-fluidsynth
+            mingw-w64-x86_64-glfw mingw-w64-x86_64-glew mingw-w64-x86_64-freetype mingw-w64-x86_64-devil mingw-w64-x86_64-freeglut mingw-w64-x86_64-zlib
+      - name: build rtmidi
+        run: |
+          mkdir dept_workspace && cd dept_workspace
+          git clone --depth=1 https://github.com/thestk/rtmidi.git
+          cd rtmidi && mkdir build && cd build
+          cmake .. -G Ninja
+          cmake --build . --target install
+          cd ../../../
+      - name: build qmidiplayer
+        run: |
+          mkdir build && cd build
+          cmake .. -G Ninja
+          cmake --build .
+          tree

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -34,3 +34,15 @@ jobs:
           cmake .. -G Ninja
           cmake --build .
           tree
+          cd ..
+      - name: package qmidiplayer
+        run: |
+          mkdir package_workspace && cd package_workspace
+          cp ../build/qmidiplayer-desktop/qmidiplayer.exe ./
+          windeployqt --no-quick-import --no-translations --no-opengl-sw --no-angle --no-system-d3d-compiler ./qmidiplayer.exe
+          cp $MINGW_PREFIX/bin/libfluidsynth-2.dll ./
+          cp $MINGW_PREFIX/bin/librtmidi.dll ./
+      - uses: actions/upload-artifact@v2
+        with:
+          name: msys2-mingw-w64-x86_64-windows
+          path: package_workspace/*

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -19,7 +19,7 @@ jobs:
             git mingw-w64-x86_64-toolchain mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake tree
             mingw-w64-x86_64-qt5
             mingw-w64-x86_64-glfw mingw-w64-x86_64-glew mingw-w64-x86_64-freetype mingw-w64-x86_64-devil mingw-w64-x86_64-freeglut mingw-w64-x86_64-zlib
-      - name: build fluidsynth-sans-glib
+      - name: Build fluidsynth-sans-glib
         id: build-fluidsynth-sans-glib
         continue-on-error: true
         run: |
@@ -30,12 +30,11 @@ jobs:
           cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
           cmake --build . --target install
           cd ../../../
-          tree
-      - name: install mingw-w64-x86_64-fluidsynth if needed
+      - name: Install mingw-w64-x86_64-fluidsynth if needed
         if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
         run: |
           pacman --noconfirm -S mingw-w64-x86_64-fluidsynth
-      - name: build rtmidi
+      - name: Build rtmidi
         run: |
           # mkdir dept_workspace
           cd dept_workspace
@@ -44,8 +43,7 @@ jobs:
           cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
           cmake --build . --target install
           cd ../../../
-          tree
-      - name: build qmidiplayer
+      - name: Build qmidiplayer
         run: |
           mkdir build && cd build
           cmake .. -G Ninja
@@ -68,6 +66,8 @@ jobs:
           cp $MINGW_PREFIX/bin/libIL.dll ./
           cp $MINGW_PREFIX/bin/libfreetype-6.dll ./
           # some other dlls
+          cp $MINGW_PREFIX/bin/libgcc_s_seh-1.dll ./
+          cp $MINGW_PREFIX/bin/libwinpthread-1.dll ./
           cp $MINGW_PREFIX/bin/libstdc++-6.dll ./
           cp $MINGW_PREFIX/bin/libintl-8.dll ./
           cp $MINGW_PREFIX/bin/libpng16-16.dll ./

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -17,11 +17,22 @@ jobs:
           update: true
           install: >-
             git mingw-w64-x86_64-toolchain mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake tree
-            mingw-w64-x86_64-qt5 mingw-w64-x86_64-fluidsynth
+            mingw-w64-x86_64-qt5
             mingw-w64-x86_64-glfw mingw-w64-x86_64-glew mingw-w64-x86_64-freetype mingw-w64-x86_64-devil mingw-w64-x86_64-freeglut mingw-w64-x86_64-zlib
+      - name: build fluidsynth-sans-glib
+        run: |
+          # no longer need mingw-w64-x86_64-fluidsynth and libglib-2.0-0.dll then.
+          mkdir dept_workspace && cd dept_workspace
+          git clone --depth=1 https://github.com/chirs241097/fluidsynth-sans-glib.git
+          cd fluidsynth-sans-glib && mkdir build && cd build
+          cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
+          cmake --build . --target install
+          cd ../../../
+          tree
       - name: build rtmidi
         run: |
-          mkdir dept_workspace && cd dept_workspace
+          # mkdir dept_workspace
+          cd dept_workspace
           git clone --depth=1 https://github.com/thestk/rtmidi.git
           cd rtmidi && mkdir build && cd build
           cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=$MINGW_PREFIX
@@ -43,8 +54,19 @@ jobs:
           # direct depts
           cp $MINGW_PREFIX/bin/libfluidsynth-2.dll ./
           cp $MINGW_PREFIX/bin/librtmidi.dll ./
+          cp $MINGW_PREFIX/bin/libportaudio-2.dll ./
+          # visualization plugin depts
+          cp $MINGW_PREFIX/bin/glfw3.dll ./
+          cp $MINGW_PREFIX/bin/glew32.dll ./
+          cp $MINGW_PREFIX/bin/zlib1.dll ./
+          cp $MINGW_PREFIX/bin/libIL.dll ./
+          cp $MINGW_PREFIX/bin/libfreetype-6.dll ./
           # some other dlls
+          cp $MINGW_PREFIX/bin/libpng16-16.dll ./
+          cp $MINGW_PREFIX/bin/libsndfile-1.dll ./
+          cp $MINGW_PREFIX/bin/libreadline8.dll ./
           cp $MINGW_PREFIX/bin/libpcre2-16-0.dll ./
+          cp $MINGW_PREFIX/bin/libharfbuzz-0.dll ./
           cp $MINGW_PREFIX/bin/libdouble-conversion.dll ./
           cp $MINGW_PREFIX/bin/libicuuc67.dll ./
           cp $MINGW_PREFIX/bin/libicuin67.dll ./

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -80,6 +80,11 @@ jobs:
           cp $MINGW_PREFIX/bin/liblcms2-2.dll ./
           cp $MINGW_PREFIX/bin/libsquish.dll ./
           cp $MINGW_PREFIX/bin/libtiff-5.dll ./
+          cp $MINGW_PREFIX/bin/libIex-2_5.dll ./
+          cp $MINGW_PREFIX/bin/libIlmThread-2_5.dll ./
+          cp $MINGW_PREFIX/bin/libImath-2_5.dll ./
+          cp $MINGW_PREFIX/bin/libgomp-1.dll ./
+          cp $MINGW_PREFIX/bin/liblzma-5.dll ./
           # some other dlls
           cp $MINGW_PREFIX/bin/libgcc_s_seh-1.dll ./
           cp $MINGW_PREFIX/bin/libwinpthread-1.dll ./

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -15,7 +15,7 @@ jobs:
           update: true
           install: >-
             git mingw-w64-x86_64-toolchain mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake tree
-            mingw-w64-x86_64-fluidsynth
+            mingw-w64-x86_64-qt5 mingw-w64-x86_64-fluidsynth
             mingw-w64-x86_64-glfw mingw-w64-x86_64-glew mingw-w64-x86_64-freetype mingw-w64-x86_64-devil mingw-w64-x86_64-freeglut mingw-w64-x86_64-zlib
       - name: build rtmidi
         run: |

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -20,6 +20,8 @@ jobs:
             mingw-w64-x86_64-qt5
             mingw-w64-x86_64-glfw mingw-w64-x86_64-glew mingw-w64-x86_64-freetype mingw-w64-x86_64-devil mingw-w64-x86_64-freeglut mingw-w64-x86_64-zlib
       - name: build fluidsynth-sans-glib
+        id: build-fluidsynth-sans-glib
+        continue-on-error: true
         run: |
           # no longer need mingw-w64-x86_64-fluidsynth and libglib-2.0-0.dll then.
           mkdir dept_workspace && cd dept_workspace
@@ -29,6 +31,10 @@ jobs:
           cmake --build . --target install
           cd ../../../
           tree
+      - name: install mingw-w64-x86_64-fluidsynth
+        if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
+        run: |
+          pacman -S mingw-w64-x86_64-fluidsynth
       - name: build rtmidi
         run: |
           # mkdir dept_workspace
@@ -75,6 +81,15 @@ jobs:
           cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/
           cp ../build/simple-visualization/libsimple-visualization.dll ./plugins/
           cp ../build/visualization/libvisualization.dll ./plugins/
+          # license file
+          cp ../COPYING ./
+          # done
+          cd ../
+      - name: install libglib-2.0-0.dll
+        if: steps.build-fluidsynth-sans-glib.outcome == 'failure'
+        run: |
+          cd package_workspace
+          cp $MINGW_PREFIX/bin/libglib-2.0-0.dll ./
       - uses: actions/upload-artifact@v2
         with:
           name: msys2-mingw-w64-x86_64-windows

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -9,6 +9,8 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -71,8 +71,15 @@ jobs:
           cp $MINGW_PREFIX/bin/glfw3.dll ./
           cp $MINGW_PREFIX/bin/glew32.dll ./
           cp $MINGW_PREFIX/bin/zlib1.dll ./
-          cp $MINGW_PREFIX/bin/libIL.dll ./
           cp $MINGW_PREFIX/bin/libfreetype-6.dll ./
+          cp $MINGW_PREFIX/bin/libIL.dll ./
+          cp $MINGW_PREFIX/bin/libHalf-2_5.dll ./
+          cp $MINGW_PREFIX/bin/libIlmImf-2_5.dll ./
+          cp $MINGW_PREFIX/bin/libjasper-4.dll ./
+          cp $MINGW_PREFIX/bin/libjpeg-8.dll ./
+          cp $MINGW_PREFIX/bin/liblcms2-2.dll ./
+          cp $MINGW_PREFIX/bin/libsquish.dll ./
+          cp $MINGW_PREFIX/bin/libtiff-5.dll ./
           # some other dlls
           cp $MINGW_PREFIX/bin/libgcc_s_seh-1.dll ./
           cp $MINGW_PREFIX/bin/libwinpthread-1.dll ./

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -60,7 +60,7 @@ jobs:
           cp $MINGW_PREFIX/bin/librtmidi.dll ./
           cp $MINGW_PREFIX/bin/libportaudio-2.dll ./
           # standalone visualization renderer
-          cp ../build/renderer/qmpvisrender.exe ./
+          cp ../build/visualization/renderer/qmpvisrender.exe ./
           # copy plugins
           mkdir plugins
           cp ../build/midifmt-plugin/libmidifmt-plugin.dll ./plugins/


### PR DESCRIPTION
This patch adds GitHub Action task to build on PR and push. The build environment is MSYS2. Packaging might be a little dirty since I hardcoded the dlls which will be used...

SQUASH SQUASH